### PR TITLE
Add 2FA authentication support for Picnic login

### DIFF
--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -59,6 +59,14 @@
       "method": "POST",
       "path": "/login"
     },
+    "generate2FA": {
+      "method": "POST",
+      "path": "/generate2fa"
+    },
+    "verify2FA": {
+      "method": "POST",
+      "path": "/verify2fa"
+    },
     "status": {
       "method": "GET",
       "path": "/status"

--- a/api.js
+++ b/api.js
@@ -6,6 +6,18 @@ module.exports = {
     return await homey.app.login(body.username, body.password);
   },
 
+  async generate2FA({ homey, body }) {
+    try {
+      return await homey.app.generate2FACode(body && body.channel ? body.channel : "SMS");
+    } catch (e) {
+      return (e && e.message) || "Failed to generate 2FA code";
+    }
+  },
+
+  async verify2FA({ homey, body }) {
+    return await homey.app.verify2FACode(body.otp);
+  },
+
   async status({ homey, query }) {
     return await homey.app.getStatus();
   },

--- a/app.js
+++ b/app.js
@@ -45,12 +45,14 @@ class Picnic extends Homey.App {
 		this.homey.settings.set("additemLock", false)
 
 		// simulate fresh install
-		//this.homey.settings.unset("order_status")
-		//this.homey.settings.unset("delivery_eta_start")
-		//this.homey.settings.unset("x-picnic-auth")
-		//this.homey.settings.unset("username")
-		//this.homey.settings.unset("password")
-		//this.homey.settings.set("order_status", "delivery_announced")
+		// this.homey.settings.unset("order_status")
+		// this.homey.settings.unset("delivery_eta_start")
+		// this.homey.settings.unset("x-picnic-auth")
+		// this.homey.settings.unset("x-picnic-auth-pending")
+		// this.homey.settings.unset("2fa_pending")
+		// this.homey.settings.unset("username")
+		// this.homey.settings.unset("password")
+		// this.homey.settings.set("order_status", "delivery_announced")
 
 		// conversion order_status code for all versions before 3.2.1
 		// this prevents unnecessary triggers being fired when <3.2.1 is upgraded to 3.2.2 and above
@@ -456,7 +458,7 @@ class Picnic extends Homey.App {
 			headers: {
 				"User-Agent": "okhttp/3.9.0",
 				"Content-Type": "application/json; charset=UTF-8",
-				"x-picnic-auth": this.homey.settings.get("x-picnic-auth"),
+				"x-picnic-auth": this.homey.settings.get("x-picnic-auth-pending") || this.homey.settings.get("x-picnic-auth"),
 				"x-picnic-did": "open.app.picnic.homey",
 				"x-picnic-agent": "30100;1.15.233-#15158"
 			}
@@ -501,7 +503,7 @@ class Picnic extends Homey.App {
 			headers: {
 				"User-Agent": "okhttp/3.9.0",
 				"Content-Type": "application/json; charset=UTF-8",
-				"x-picnic-auth": this.homey.settings.get("x-picnic-auth"),
+				"x-picnic-auth": this.homey.settings.get("x-picnic-auth-pending") || this.homey.settings.get("x-picnic-auth"),
 				"x-picnic-did": "open.app.picnic.homey",
 				"x-picnic-agent": "30100;1.15.233-#15158"
 			}
@@ -520,6 +522,8 @@ class Picnic extends Homey.App {
 						if (newAuth) {
 							this.debug("2FA verification succeeded, new auth token received.")
 							this.homey.settings.set("x-picnic-auth", newAuth);
+							this.homey.settings.unset("x-picnic-auth-pending");
+							this.homey.settings.set("2fa_pending", false);
 						} else {
 							this.debug("2FA verification succeeded but no new auth token in response, keeping existing token.")
 						}

--- a/app.js
+++ b/app.js
@@ -386,7 +386,7 @@ class Picnic extends Homey.App {
 			port: 443,
 			path: '/api/15/user/login',
 			method: 'POST',
-			timeout: 1000,
+			timeout: 5000,
 			headers: {
 				"User-Agent": "okhttp/3.9.0",
 				"Content-Type": "application/json; charset=UTF-8",
@@ -397,25 +397,138 @@ class Picnic extends Homey.App {
 
 		return new Promise((resolve) => {
 			const req = http.request(options, (res) => {
-				if (res.statusCode == 200) {
-					this.debug("Authentication succeeded.")
-					this.debug("JWT:" + res.headers['x-picnic-auth'])
-					this.homey.settings.set("x-picnic-auth", res.headers['x-picnic-auth'])
-					this.homey.settings.set("username", username)
-					this.homey.settings.set("password", password)
-					this.pollOrder();
-					resolve("success");
-				}
-				else {
-					this.debug("ERROR: Authentication failed.")
-					this.homey.app.changeInterval(DEFAULT_POLL_INTERVAL);
-					resolve('Problem with request or authentication failed.');
-				}
+				let body = '';
+				res.setEncoding('utf8');
+				res.on('data', (chunk) => { body += chunk; });
+				res.on('end', () => {
+					if (res.statusCode == 200) {
+						this.debug("Authentication succeeded.")
+						this.debug("JWT:" + res.headers['x-picnic-auth'])
+						this.homey.settings.set("x-picnic-auth", res.headers['x-picnic-auth'])
+						this.homey.settings.set("username", username)
+						this.homey.settings.set("password", password)
+
+						let responseData = {};
+						try { responseData = JSON.parse(body); } catch (e) { /* empty or non-json body is fine */ }
+
+						if (responseData.second_factor_authentication_required === true) {
+							this.debug("2FA required, requesting SMS code.")
+							this.generate2FACode("SMS")
+								.then(() => resolve("2fa_required"))
+								.catch(() => resolve("2fa_required"));
+						} else {
+							this.pollOrder();
+							resolve("success");
+						}
+					}
+					else {
+						this.debug("ERROR: Authentication failed. Status: " + res.statusCode)
+						this.homey.app.changeInterval(DEFAULT_POLL_INTERVAL);
+						resolve('Problem with request or authentication failed.');
+					}
+				});
 			});
 
 			req.on('error', (e) => {
 				this.debug("ERROR: Problem with request or authentication failed.")
 				resolve('Problem with request or authentication failed.');
+			});
+
+			req.write(json_data);
+			req.end();
+		});
+	}
+
+	async generate2FACode(channel) {
+		var json_data = JSON.stringify({ channel: channel || "SMS" });
+		var options = {
+			hostname: this.homey.settings.get("url"),
+			port: 443,
+			path: '/api/15/user/2fa/generate',
+			method: 'POST',
+			timeout: 5000,
+			headers: {
+				"User-Agent": "okhttp/3.9.0",
+				"Content-Type": "application/json; charset=UTF-8",
+				"x-picnic-auth": this.homey.settings.get("x-picnic-auth"),
+				"x-picnic-did": "open.app.picnic.homey",
+				"x-picnic-agent": "30100;1.15.233-#15158"
+			}
+		}
+
+		this.debug("Requesting 2FA code via " + (channel || "SMS"))
+
+		return new Promise((resolve, reject) => {
+			const req = http.request(options, (res) => {
+				let body = '';
+				res.setEncoding('utf8');
+				res.on('data', (chunk) => { body += chunk; });
+				res.on('end', () => {
+					if (res.statusCode >= 200 && res.statusCode < 300) {
+						this.debug("2FA code requested successfully.")
+						resolve("success");
+					} else {
+						this.debug("ERROR: 2FA code request failed. Status: " + res.statusCode + " body: " + body)
+						reject(new Error("2FA code request failed: " + res.statusCode));
+					}
+				});
+			});
+
+			req.on('error', (e) => {
+				this.debug("ERROR: Problem with 2FA generate request: " + e.message)
+				reject(e);
+			});
+
+			req.write(json_data);
+			req.end();
+		});
+	}
+
+	async verify2FACode(otp) {
+		var json_data = JSON.stringify({ otp: String(otp || "") });
+		var options = {
+			hostname: this.homey.settings.get("url"),
+			port: 443,
+			path: '/api/15/user/2fa/verify',
+			method: 'POST',
+			timeout: 5000,
+			headers: {
+				"User-Agent": "okhttp/3.9.0",
+				"Content-Type": "application/json; charset=UTF-8",
+				"x-picnic-auth": this.homey.settings.get("x-picnic-auth"),
+				"x-picnic-did": "open.app.picnic.homey",
+				"x-picnic-agent": "30100;1.15.233-#15158"
+			}
+		}
+
+		this.debug("Verifying 2FA code")
+
+		return new Promise((resolve) => {
+			const req = http.request(options, (res) => {
+				let body = '';
+				res.setEncoding('utf8');
+				res.on('data', (chunk) => { body += chunk; });
+				res.on('end', () => {
+					if (res.statusCode >= 200 && res.statusCode < 300) {
+						const newAuth = res.headers['x-picnic-auth'];
+						if (newAuth) {
+							this.debug("2FA verification succeeded, new auth token received.")
+							this.homey.settings.set("x-picnic-auth", newAuth);
+						} else {
+							this.debug("2FA verification succeeded but no new auth token in response, keeping existing token.")
+						}
+						this.pollOrder();
+						resolve("success");
+					} else {
+						this.debug("ERROR: 2FA verification failed. Status: " + res.statusCode + " body: " + body)
+						resolve("Invalid 2FA code. Please try again.");
+					}
+				});
+			});
+
+			req.on('error', (e) => {
+				this.debug("ERROR: Problem with 2FA verify request: " + e.message)
+				resolve("Problem with request or 2FA verification failed.");
 			});
 
 			req.write(json_data);

--- a/app.js
+++ b/app.js
@@ -404,19 +404,25 @@ class Picnic extends Homey.App {
 					if (res.statusCode == 200) {
 						this.debug("Authentication succeeded.")
 						this.debug("JWT:" + res.headers['x-picnic-auth'])
-						this.homey.settings.set("x-picnic-auth", res.headers['x-picnic-auth'])
-						this.homey.settings.set("username", username)
-						this.homey.settings.set("password", password)
 
 						let responseData = {};
 						try { responseData = JSON.parse(body); } catch (e) { /* empty or non-json body is fine */ }
 
+						this.homey.settings.set("username", username)
+						this.homey.settings.set("password", password)
+
 						if (responseData.second_factor_authentication_required === true) {
 							this.debug("2FA required, requesting SMS code.")
+							this.homey.settings.set("x-picnic-auth-pending", res.headers['x-picnic-auth'])
+							this.homey.settings.set("2fa_pending", true)
+							this.homey.settings.unset("x-picnic-auth")
 							this.generate2FACode("SMS")
 								.then(() => resolve("2fa_required"))
 								.catch(() => resolve("2fa_required"));
 						} else {
+							this.homey.settings.unset("x-picnic-auth-pending")
+							this.homey.settings.set("2fa_pending", false)
+							this.homey.settings.set("x-picnic-auth", res.headers['x-picnic-auth'])
 							this.pollOrder();
 							resolve("success");
 						}

--- a/app.json
+++ b/app.json
@@ -60,6 +60,14 @@
       "method": "POST",
       "path": "/login"
     },
+    "generate2FA": {
+      "method": "POST",
+      "path": "/generate2fa"
+    },
+    "verify2FA": {
+      "method": "POST",
+      "path": "/verify2fa"
+    },
     "status": {
       "method": "GET",
       "path": "/status"

--- a/locales/en.json
+++ b/locales/en.json
@@ -8,7 +8,15 @@
         "authenticated": "Authentication status",
         "order-status": "Order status",
         "order-status-button": "order status",
-        "save-button": "Save changes"
+        "save-button": "Save changes",
+        "2fa": {
+            "info": "Two-factor authentication is required. An SMS code has been sent to the phone number registered with your Picnic account.",
+            "code-label": "SMS code",
+            "verify-button": "Verify",
+            "resend-button": "Resend code",
+            "code-sent": "A new SMS code has been sent.",
+            "verify-failed": "Verification failed. Please try again."
+        }
     },
     "tokens": {
         "order": {

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -8,7 +8,15 @@
         "authenticated": "Authenticatie status",
         "order-status": "Bestelling status",
         "order-status-button": "bestelling status",
-        "save-button": "Wijzigingen opslaan"
+        "save-button": "Wijzigingen opslaan",
+        "2fa": {
+            "info": "Tweestapsverificatie is vereist. Er is een SMS-code verzonden naar het telefoonnummer van je Picnic-account.",
+            "code-label": "SMS-code",
+            "verify-button": "Verifieer",
+            "resend-button": "Code opnieuw sturen",
+            "code-sent": "Er is een nieuwe SMS-code verzonden.",
+            "verify-failed": "Verificatie mislukt. Probeer het opnieuw."
+        }
     },
     "tokens": {
         "order": {

--- a/settings/index.html
+++ b/settings/index.html
@@ -42,6 +42,15 @@
               <div><var id="order-status">loading...</var></div>
             </div>
           </form>
+          <div id="twofa-section" style="display:none; margin-top:15px; padding:10px; border:1px solid #ccc; border-radius:4px;">
+            <p data-i18n="settings.2fa.info"></p>
+            <div class="form-group">
+              <label for="otp" data-i18n="settings.2fa.code-label"></label>
+              <input class="form-control" id="otp" type="text" inputmode="numeric" autocomplete="one-time-code" maxlength="6" value="" />
+            </div>
+            <button id="verify-2fa" class="right"><var style="font-style:normal;" data-i18n="settings.2fa.verify-button"></var></button>
+            <button id="resend-2fa" class="right"><var style="font-style:normal;" data-i18n="settings.2fa.resend-button"></var></button>
+          </div>
           <button id="reset-order-status" class="right">Reset <var style="font-style:normal;" data-i18n="settings.order-status-button"></button>
           <button id="save" class="right"><var style="font-style:normal;" data-i18n="settings.save-button"></button>
         </div>
@@ -163,6 +172,10 @@
           var statusElement = document.getElementById('status');
           var orderStatusElement = document.getElementById('order-status');
           var resetOrderStatusElement = document.getElementById('reset-order-status');
+          var twofaSection = document.getElementById('twofa-section');
+          var otpElement = document.getElementById('otp');
+          var verify2faElement = document.getElementById('verify-2fa');
+          var resend2faElement = document.getElementById('resend-2fa');
 
           Homey.api('GET', '/status', null, function ( err, result ) {
             if ( err ) return Homey.alert( err );
@@ -205,9 +218,41 @@
               Homey.set('username', usernameElement.value)
               Homey.set('password', passwordElement.value)
 
+              if (result === '2fa_required') {
+                twofaSection.style.display = 'block';
+                otpElement.value = '';
+                otpElement.focus();
+                return;
+              }
+
+              if (result !== 'success') {
+                return Homey.alert(result);
+              }
+
               window.location.reload();
             });
 
+          });
+
+          verify2faElement.addEventListener('click', function(e) {
+            var otp = (otpElement.value || '').trim();
+            if (!otp) {
+              return Homey.alert(Homey.__('settings.2fa.code-label'));
+            }
+            Homey.api('POST', '/verify2fa', { 'otp': otp }, function( err, result ) {
+              if( err ) return Homey.alert(err);
+              if (result !== 'success') {
+                return Homey.alert(result || Homey.__('settings.2fa.verify-failed'));
+              }
+              window.location.reload();
+            });
+          });
+
+          resend2faElement.addEventListener('click', function(e) {
+            Homey.api('POST', '/generate2fa', { 'channel': 'SMS' }, function( err, result ) {
+              if( err ) return Homey.alert(err);
+              Homey.alert(Homey.__('settings.2fa.code-sent'));
+            });
           });
         }
         </script>

--- a/settings/index.html
+++ b/settings/index.html
@@ -251,6 +251,9 @@
           resend2faElement.addEventListener('click', function(e) {
             Homey.api('POST', '/generate2fa', { 'channel': 'SMS' }, function( err, result ) {
               if( err ) return Homey.alert(err);
+              if (result !== 'success') {
+                return Homey.alert(result || Homey.__('settings.2fa.verify-failed'));
+              }
               Homey.alert(Homey.__('settings.2fa.code-sent'));
             });
           });


### PR DESCRIPTION
## Summary
- Adds two-factor authentication (2FA) support, required by Picnic's login API
- Introduces new `generate2FA` and `verify2FA` API endpoints (`/api/15/user/2fa/generate`, `/api/15/user/2fa/verify`)
- When the login response contains `second_factor_authentication_required: true`, an SMS code is automatically requested and the settings UI shows a 2FA entry form with verify/resend buttons
- Adds English and Dutch translations for the 2FA UI strings
- Increases login request timeout from 1s to 5s to avoid premature failures

## Test plan
- [ ] Log in with a Picnic account that has 2FA enabled — verify SMS is received and the 2FA form appears
- [ ] Enter the received SMS code and confirm authentication completes and polling starts
- [ ] Click "Resend code" and confirm a new SMS arrives
- [ ] Enter an invalid code and confirm the error message is shown
- [ ] Log in with an account that does not require 2FA and confirm the existing flow still works